### PR TITLE
Add secondary dns resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,3 +77,5 @@ require (
 )
 
 go 1.19
+
+replace github.com/dnsimple/dnsimple-go v1.2.0 => github.com/stormforge-llc/dnsimple-go v1.2.0-stormforge1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dnsimple/dnsimple-go v1.2.0 h1:ddTGyLVKly5HKb5L65AkLqFqwZlWo3WnR0BlFZlIddM=
-github.com/dnsimple/dnsimple-go v1.2.0/go.mod h1:z/cs26v/eiRvUyXsHQBLd8lWF8+cD6GbmkPH84plM4U=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -187,6 +185,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
+github.com/stormforge-llc/dnsimple-go v1.2.0-stormforge1 h1:GlIQ10scPh8Ic57xFRCclW+/YSNzjNiyomg8bVZJr8c=
+github.com/stormforge-llc/dnsimple-go v1.2.0-stormforge1/go.mod h1:HSd18mvJBieHXWNT3blyZoxIKwy+12J+68c36xb9Mso=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -176,6 +176,8 @@ func (p *DnsimpleProvider) Resources(ctx context.Context) []func() resource.Reso
 		resources.NewEmailForwardResource,
 		resources.NewLetsEncryptCertificateResource,
 		resources.NewZoneRecordResource,
+		resources.NewDomainSecondaryZoneResource,
+		resources.NewDomainSecondaryServerResource,
 	}
 }
 

--- a/internal/framework/resources/domain_secondary_dns_server_resource.go
+++ b/internal/framework/resources/domain_secondary_dns_server_resource.go
@@ -1,0 +1,245 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/common"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/utils"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &DomainSecondaryServerResource{}
+	_ resource.ResourceWithConfigure   = &DomainSecondaryServerResource{}
+)
+
+func NewDomainSecondaryServerResource() resource.Resource {
+	return &DomainSecondaryServerResource{}
+}
+
+// DomainSecondaryServerResource defines the resource implementation.
+type DomainSecondaryServerResource struct {
+	config *common.DnsimpleProviderConfig
+}
+
+// DomainSecondaryServerResourceModel describes the resource data model.
+type DomainSecondaryServerResourceModel struct {
+	Name         types.String `tfsdk:"name"`
+	IPAddress    types.String `tfsdk:"ip_address"`
+	Port         types.Int64  `tfsdk:"port"`
+	ID           types.Int64  `tfsdk:"id"`
+	Zones        types.Set    `tfsdk:"zones"`
+}
+
+func (r *DomainSecondaryServerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_domain_secondary_server"
+}
+
+func (r *DomainSecondaryServerResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "DNSimple domain secondary server resource",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"address": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"port": schema.Int64Attribute{
+				Required: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"zones": schema.SetAttribute{
+				Required: true,
+				ElementType: types.StringType,
+				// For now, we do in-place replace, but we can technicaly link one-by-one
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": common.IDInt64Attribute(),
+		},
+	}
+}
+
+func (r *DomainSecondaryServerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*common.DnsimpleProviderConfig)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *provider.DnsimpleProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.config = config
+}
+
+func (r *DomainSecondaryServerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *DomainSecondaryServerResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serverAttributes := dnsimple.SecondaryServer{
+		Name: data.Name.ValueString(),
+		IP: data.IPAddress.ValueString(),
+		Port: uint64(data.Port.ValueInt64()),
+	}
+
+	response, err := r.config.Client.SecondaryDNS.CreatePrimaryServer(ctx, r.config.AccountID, serverAttributes)
+
+	if err != nil {
+		var errorResponse *dnsimple.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			resp.Diagnostics.Append(utils.AttributeErrorsToDiagnostics(errorResponse)...)
+			return
+		}
+
+		resp.Diagnostics.AddError(
+			"failed to create DNSimple secondary DNS primary server",
+			err.Error(),
+		)
+		return
+	}
+
+	for _, zoneValue := range data.Zones.Elements() {
+		tfv, err := zoneValue.ToTerraformValue(ctx)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to get zone name as string when creating DNSimple secondary DNS server",
+				err.Error(),
+			)
+			return
+		}
+		var zone string
+		if err := tfv.As(&zone); err != nil {
+			resp.Diagnostics.AddError(
+				"failed to convert zone name to string when creating DNSimple secondary DNS server",
+				err.Error(),
+			)
+			return
+		}
+
+		if _, err := r.config.Client.SecondaryDNS.LinkPrimaryServerToSecondaryZone(ctx, r.config.AccountID, string(data.ID.ValueInt64()), zone); err != nil {
+			var errorResponse *dnsimple.ErrorResponse
+			if errors.As(err, &errorResponse) {
+				resp.Diagnostics.Append(utils.AttributeErrorsToDiagnostics(errorResponse)...)
+				return
+			}
+
+			resp.Diagnostics.AddError(
+				"failed to link zone to DNSimple secondary DNS server",
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	r.updateModelFromAPIResponse(response.Data, data)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *DomainSecondaryServerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *DomainSecondaryServerResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := r.config.Client.SecondaryDNS.GetPrimaryServer(ctx, r.config.AccountID, string(data.ID.ValueInt64()))
+
+	if err != nil {
+		var errorResponse *dnsimple.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			resp.Diagnostics.Append(utils.AttributeErrorsToDiagnostics(errorResponse)...)
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("failed to read DNSimple Domain: %s", data.Name.ValueString()),
+			err.Error(),
+		)
+		return
+	}
+
+	r.updateModelFromAPIResponse(response.Data, data)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *DomainSecondaryServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// No-op
+}
+
+func (r *DomainSecondaryServerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *DomainSecondaryServerResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("Deleting DNSimple secondary DNS primary server: %s, %s", data.Name, data.ID))
+
+	_, err := r.config.Client.SecondaryDNS.DeletePrimaryServer(ctx, r.config.AccountID, string(data.ID.ValueInt64()))
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("failed to delete DNSimple secondary DNS primary server: %s", data.Name.ValueString()),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *DomainSecondaryServerResource) updateModelFromAPIResponse(server *dnsimple.SecondaryServer, data *DomainSecondaryServerResourceModel) {
+	data.ID = types.Int64Value(server.ID)
+	data.Name = types.StringValue(server.Name)
+	data.IPAddress = types.StringValue(server.IP)
+	data.Port = types.Int64Value(int64(server.Port))
+	zones := make([]attr.Value, 0, len(server.LinkedSecondaryZones))
+	for _, z := range server.LinkedSecondaryZones {
+		zones = append(zones, basetypes.NewStringValue(z))
+	}
+	data.Zones = basetypes.NewSetValueMust(types.StringType, zones)
+}

--- a/internal/framework/resources/domain_secondary_dns_server_resource.go
+++ b/internal/framework/resources/domain_secondary_dns_server_resource.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"strconv"
 	"errors"
 	"fmt"
 
@@ -154,7 +155,7 @@ func (r *DomainSecondaryServerResource) Create(ctx context.Context, req resource
 			return
 		}
 
-		if _, err := r.config.Client.SecondaryDNS.LinkPrimaryServerToSecondaryZone(ctx, r.config.AccountID, string(data.ID.ValueInt64()), zone); err != nil {
+		if _, err := r.config.Client.SecondaryDNS.LinkPrimaryServerToSecondaryZone(ctx, r.config.AccountID, strconv.Itoa(int(data.ID.ValueInt64())), zone); err != nil {
 			var errorResponse *dnsimple.ErrorResponse
 			if errors.As(err, &errorResponse) {
 				resp.Diagnostics.Append(utils.AttributeErrorsToDiagnostics(errorResponse)...)
@@ -185,7 +186,7 @@ func (r *DomainSecondaryServerResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	response, err := r.config.Client.SecondaryDNS.GetPrimaryServer(ctx, r.config.AccountID, string(data.ID.ValueInt64()))
+	response, err := r.config.Client.SecondaryDNS.GetPrimaryServer(ctx, r.config.AccountID, strconv.Itoa(int(data.ID.ValueInt64())))
 
 	if err != nil {
 		var errorResponse *dnsimple.ErrorResponse
@@ -221,7 +222,7 @@ func (r *DomainSecondaryServerResource) Delete(ctx context.Context, req resource
 
 	tflog.Info(ctx, fmt.Sprintf("Deleting DNSimple secondary DNS primary server: %s, %s", data.Name, data.ID))
 
-	_, err := r.config.Client.SecondaryDNS.DeletePrimaryServer(ctx, r.config.AccountID, string(data.ID.ValueInt64()))
+	_, err := r.config.Client.SecondaryDNS.DeletePrimaryServer(ctx, r.config.AccountID, strconv.Itoa(int(data.ID.ValueInt64())))
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/framework/resources/domain_secondary_dns_zone_resource.go
+++ b/internal/framework/resources/domain_secondary_dns_zone_resource.go
@@ -1,0 +1,167 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/common"
+	"github.com/terraform-providers/terraform-provider-dnsimple/internal/framework/utils"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &DomainSecondaryZoneResource{}
+	_ resource.ResourceWithConfigure   = &DomainSecondaryZoneResource{}
+)
+
+func NewDomainSecondaryZoneResource() resource.Resource {
+	return &DomainSecondaryZoneResource{}
+}
+
+// DomainSecondaryZoneResource defines the resource implementation.
+type DomainSecondaryZoneResource struct {
+	config *common.DnsimpleProviderConfig
+}
+
+// DomainSecondaryZoneResourceModel describes the resource data model.
+type DomainSecondaryZoneResourceModel struct {
+	Name types.String `tfsdk:"name"`
+}
+
+func (r *DomainSecondaryZoneResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_domain_secondary_zone"
+}
+
+func (r *DomainSecondaryZoneResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "DNSimple domain secondary zone resource",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"id": common.IDInt64Attribute(),
+		},
+	}
+}
+
+func (r *DomainSecondaryZoneResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*common.DnsimpleProviderConfig)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *provider.DnsimpleProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.config = config
+}
+
+func (r *DomainSecondaryZoneResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *DomainSecondaryZoneResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := r.config.Client.SecondaryDNS.CreateSecondaryZone(ctx, r.config.AccountID, dnsimple.SecondaryZone{Zone: dnsimple.Zone{Name: data.Name.ValueString()}})
+	if err != nil {
+		var errorResponse *dnsimple.ErrorResponse
+		if errors.As(err, &errorResponse) {
+			resp.Diagnostics.Append(utils.AttributeErrorsToDiagnostics(errorResponse)...)
+			return
+		}
+
+		resp.Diagnostics.AddError(
+			"failed to create DNSimple secondary DNS zone",
+			err.Error(),
+		)
+	}
+
+	r.updateModelFromAPIResponse(&response.Data.Zone, data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *DomainSecondaryZoneResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *DomainSecondaryZoneResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	zoneResponse, err := r.config.Client.Zones.GetZone(ctx, r.config.AccountID, data.Name.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("failed to read DNSimple zone %q", data.Name),
+			err.Error(),
+		)
+		return
+	}
+
+	// Unfortunately, DNSimple secondary DNS API doesn't have a Get API. Best you can do is infer it. 
+	serversResponse, err := r.config.Client.SecondaryDNS.ListPrimaryServers(ctx, r.config.AccountID, &dnsimple.SecondaryServerListOptions{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"failed to read DNSimple secondary servers",
+			err.Error(),
+		)
+		return
+	}
+
+	found := false
+	for _, server := range serversResponse.Data {
+		for _, zone := range server.LinkedSecondaryZones {
+			if zone == data.Name.ValueString() {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			break
+		}
+	}
+
+	if !found {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("DNSimple secondary zone %q not found", data.Name),
+			err.Error(),
+		)
+		return
+	}
+
+	r.updateModelFromAPIResponse(zoneResponse.Data, data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *DomainSecondaryZoneResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// No-op
+}
+
+func (r *DomainSecondaryZoneResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// No-op; DNSimple's secondary DNS zone API has no "delete secondary zone" API, only a "delete zone" API
+}
+
+func (r *DomainSecondaryZoneResource) updateModelFromAPIResponse(server *dnsimple.Zone, data *DomainSecondaryZoneResourceModel) {
+	data.Name = types.StringValue(server.Name)
+}


### PR DESCRIPTION
- Adds dnsimple_domain_secondary_server resource
- Adds dnsimple_domain_secondary_zone resource
- Use forked version of dnsimple-go to provide Secondary APIs